### PR TITLE
Fix incomplete PWM initialization for 8th slice.

### DIFF
--- a/src/drivers/hardware_specific/rp2040_mcu.cpp
+++ b/src/drivers/hardware_specific/rp2040_mcu.cpp
@@ -91,7 +91,7 @@ void syncSlices() {
 		pwm_set_counter(i, 0);
 	}
 	// enable all slices
-	pwm_set_mask_enabled(0x7F);
+	pwm_set_mask_enabled(0xFF);
 }
 
 


### PR DESCRIPTION
This fixes our second channel. I found with an oscilloscope that pins 14 and 15 never had any PWM output, and found with a debugger that the associated PWM channel was never enabled. I found this line which intends to enable all channels at once, but uses a mask that misses that last channel. I confirmed the motor now calibrates and works with this fix.